### PR TITLE
returns a promise, too

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,29 @@ breaker.runCommand('http://yahoo.com', (err, resp) => {
     }
     // Here there is no error and it's possible to proceed with the resp object
 });
-
 ```
 
-**Note** The function signature of the callback passed to command is `callback(err, data)`. Extra parameters passed to the callback are ignored.
+The `runCommand` method will return a promise if a callback is not supplied.
+
+```js
+const Breaker = require('circuit-fuses');
+const request = require('request');
+const command = request.get
+// To setup the fuse, instantiate a new Breaker with the command to run
+const breaker = new Breaker(command);
+
+breaker.runCommand('http://yahoo.com')
+    .then(resp => {
+        // Here there is no error and it's possible to proceed with the resp object
+    })
+    .catch(err => {
+        /* If the circuit is open the command is not run, and an error
+         * with message "CircuitBreaker Open" is returned.
+         * In this case, you can switch on the error and have a fallback technique
+         */
+        // ... stuff
+    });
+```
 
 ### Constructor
 `constructor(command, options)` 
@@ -52,7 +71,7 @@ breaker.runCommand('http://yahoo.com', (err, resp) => {
 | options.shouldRetry | Function | No | Special logic to should circuit retries | () => true |
 
 ### Short circuiting the retry logic
-Normally, the circuit breaker will retry with exponential backoff until the max number of retries has been reached or the breaker has opened due to max failures. You may have operations that you want to immediately fail under certain conditions. In this situation, a shouldRetry option is available. This is a function that receives the err object and arguments passed to the runCommand function.
+Normally, the circuit breaker will retry with exponential back off until the max number of retries has been reached or the breaker has opened due to max failures. You may have operations that you want to immediately fail under certain conditions. In this situation, a shouldRetry option is available. This is a function that receives the err object and arguments passed to the runCommand function.
 
 For example, short circuit when runCommand is called with "MyArg" and the error contains a status code of 404:
 
@@ -70,7 +89,7 @@ To run the command passed to the constructor
 | Parameter        | Type  | Required  |  Description |
 | :-------------   | :---- | :---- | :-------------|
 | args        | Arguments | No | The arguments to pass to the command |
-| callback | Function | Yes | The callback to call when the command returns |
+| callback | Function | No | The callback to call when the command returns |
 
 ### Get Total Number Requests
 Returns the total number of requests from the circuit breaker
@@ -106,6 +125,9 @@ Returns the average request time taken
 Returns boolean whether the circuit breaker is closed
 
 `isClosed()`
+
+### Get a holistic set of the above metrics
+`stats()`
 
 ## Testing
 

--- a/index.js
+++ b/index.js
@@ -54,7 +54,7 @@ class CircuitBreaker {
         const args = Array.prototype.slice.call(arguments);
         let callback;
 
-        if (typeof args[args.length - 1] === 'function') {
+        if (args.length >= 1 && typeof args[args.length - 1] === 'function') {
             callback = args.pop();
         }
 
@@ -145,6 +145,27 @@ class CircuitBreaker {
      */
     getAverageRequestTime() {
         return this.breaker.stats.averageResponseTime();
+    }
+
+    /**
+    * Retrieve stats for the breaker
+    * @method   stats
+    * @returns  {Object}           Object containing stats for the breaker
+    */
+    stats() {
+        return {
+            requests: {
+                total: this.breaker.stats.totalRequests,
+                timeouts: this.breaker.stats.timeouts,
+                success: this.breaker.stats.successfulResponses,
+                failure: this.breaker.stats.failedResponses,
+                concurrent: this.breaker.stats.concurrentRequests(),
+                averageTime: this.breaker.stats.averageResponseTime()
+            },
+            breaker: {
+                isClosed: this.breaker.isClosed()
+            }
+        };
     }
 }
 

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 'use strict';
+
 /* eslint-disable no-underscore-dangle */
 const circuitbreaker = require('circuitbreaker');
 const retryFn = require('retry-function');
@@ -47,23 +48,40 @@ class CircuitBreaker {
      * Retry wrapper for the circuit breaker to retry on failure as long as circuit is closed
      * @method runCommand
      * @param  {arguments}   arguments           List of arguments to call the circuit breaker command with
-     * @param  {Function}    callback            Last argument is the callback to callback upon completion
+     * @param  {Function}    [callback]          Last argument is the callback to callback upon completion
      */
     runCommand() {
         const args = Array.prototype.slice.call(arguments);
-        const callback = args.pop();
+        let callback;
+
+        if (typeof args[args.length - 1] === 'function') {
+            callback = args.pop();
+        }
+
         const wrapBreaker = (cb) => {
             this.breaker.apply(this.breaker, args)
-            .then((data) => cb(null, data), (err) => cb(err));
+            .then(data => cb(null, data), err => cb(err));
         };
         const shouldRetry = this.shouldRetry;
 
-        retryFn({
-            method: wrapBreaker,
-            context: this,
-            options: this.retryOptions,
-            shouldRetry: (err) => err && this.isClosed() && shouldRetry(err, args)
-        }, callback);
+        return new Promise((resolve, reject) => {
+            retryFn({
+                method: wrapBreaker,
+                context: this,
+                options: this.retryOptions,
+                shouldRetry: err => err && this.isClosed() && shouldRetry(err, args)
+            }, (err, ...data) => {
+                if (typeof callback === 'function') {
+                    return callback(err, ...data);
+                }
+
+                if (err) {
+                    return reject(err);
+                }
+
+                return resolve(...data);
+            });
+        });
     }
 
     /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "circuit-fuses",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Wrapper around node-circuitbreaker to define a callback interface",
   "main": "index.js",
   "scripts": {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,4 +1,5 @@
 'use strict';
+
 const assert = require('chai').assert;
 const sinon = require('sinon');
 const mockery = require('mockery');
@@ -219,6 +220,28 @@ describe('index test', () => {
                 assert.callCount(breakerMock, 3);
                 done();
             });
+        });
+
+        it('implements a promise interface when no callback', () => {
+            breakerMock.resolves('foo');
+
+            return breaker.runCommand('1', '2')
+                .then((data) => {
+                    assert.calledWith(breakerMock, '1', '2');
+                    assert.equal(data, 'foo');
+                });
+        });
+
+        it('handles broken promise when no callback', () => {
+            const breakerError = new Error('nope');
+
+            breakerMock.rejects(breakerError);
+
+            return breaker.runCommand('1', '2')
+                .catch((err) => {
+                    assert.calledWith(breakerMock, '1', '2');
+                    assert.deepEqual(err, breakerError);
+                });
         });
     });
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -303,4 +303,28 @@ describe('index test', () => {
             assert.equal(breaker.isClosed(), false);
         });
     });
+
+    describe('stats', () => {
+        it('should provide a unified stats interface', () => {
+            breakerMock.isClosed.returns(false);
+            statsMock.averageResponseTime.returns(6);
+            statsMock.concurrentRequests.returns(5);
+
+            const breaker = new Breaker();
+
+            assert.deepEqual(breaker.stats(), {
+                requests: {
+                    total: 1,
+                    timeouts: 2,
+                    success: 3,
+                    failure: 4,
+                    concurrent: 5,
+                    averageTime: 6
+                },
+                breaker: {
+                    isClosed: false
+                }
+            });
+        });
+    });
 });


### PR DESCRIPTION
All of the usage of circuit fuses looks a little boilerplate when we call `runCommand`. This PR wraps `runCommand` in a promise and returns it. It will still call the callback function if one is provided.
