### PR TITLE
Pull in the new retry-function

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,6 @@
   "dependencies": {
     "circuitbreaker": "^0.2.1",
     "request": "^2.73.0",
-    "retry-function": "^1.1.1"
+    "retry-function": "^2.0.0"
   }
 }


### PR DESCRIPTION
The new retry-function now uses `joi 9.1`

Hope this helps with https://github.com/screwdriver-cd/screwdriver/issues/274
