### PR TITLE
Create a FuseBox class to group multiple breakers

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ npm install circuit-fuses
 This module wraps the [node-circuitbreaker] and provides a simple callback interface for handling the circuit breaker.
 
 ```js
-const Breaker = require('circuit-fuses');
+const Breaker = require('circuit-fuses').breaker;
 const request = require('request');
 const command = request.get
 // To setup the fuse, instantiate a new Breaker with the command to run
@@ -33,7 +33,7 @@ breaker.runCommand('http://yahoo.com', (err, resp) => {
 The `runCommand` method will return a promise if a callback is not supplied.
 
 ```js
-const Breaker = require('circuit-fuses');
+const Breaker = require('circuit-fuses').breaker;
 const request = require('request');
 const command = request.get
 // To setup the fuse, instantiate a new Breaker with the command to run
@@ -128,6 +128,34 @@ Returns boolean whether the circuit breaker is closed
 
 ### Get a holistic set of the above metrics
 `stats()`
+
+## Using Fuseboxes
+
+A FuseBox is a collection of circuit breakers. If one circuit breaker in the fuse box breaks, the others break as well. To create a new fusebox:
+
+```
+const FuseBox = require('circuit-fuses').box;
+const fusebox = new FuseBox();
+```
+
+To add circuit breakers to the fuse box, use the `addFuse()` method.
+
+`addFuse(circuitbreaker)`
+
+| Parameter        | Type  | Required  |  Description |
+| :-------------   | :---- | :---- | :-------------|
+| circuitbreaker   | CircuitBreaker | Yes | The circuit breaker to add to the fuse box |
+
+Here's an example:
+
+```
+var breaker1 = new Breaker('testFn');
+var breaker2 = new Breaker('testFn2');
+var breaker3 = new Breaker('testFn3');
+fusebox.addFuse(breaker1);
+fusebox.addFuse(breaker2);
+```
+In the above case, if breaker1 trips, breaker2 will trip as well because both of them belong to the same fuse box.
 
 ## Testing
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "circuit-fuses",
-  "version": "2.1.0",
+  "version": "3.0.0",
   "description": "Wrapper around node-circuitbreaker to define a callback interface",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Use case: To create multiple circuit breakers with different settings and group them into one 'fusebox' so they can all be tripped if one breaks.