### PR TITLE
feat(logging): Log on forceOpen to detect if tripped through fusebox

### DIFF
--- a/index.js
+++ b/index.js
@@ -163,7 +163,10 @@ was tripped on ${new Date().toUTCString()}`);
      * @method forceOpen
      */
     forceOpen() {
-        this.breaker.forceOpen();
+        if (this.breaker.isClosed()) {
+            console.log(`Forcing open ${this.command.toString()}`);
+            this.breaker.forceOpen();
+        }
     }
 
     /**

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -363,5 +363,18 @@ describe('index test', () => {
             assert.isFalse(breaker3.isClosed());
             assert.isTrue(breaker4.isClosed());
         });
+
+        it('should not try to forceOpen when already open', () => {
+            const breaker1 = new Breaker('testFn');
+
+            sinon.spy(breaker1.breaker, 'forceOpen');
+            breakerMock.isClosed = sinon.stub().returns(true);
+            breaker1.forceOpen();
+
+            breakerMock.isClosed = sinon.stub().returns(false);
+            breaker1.forceOpen();
+
+            assert(breaker1.breaker.forceOpen.calledOnce);
+        });
     });
 });


### PR DESCRIPTION
That way we know if a fuse was tripped because of timeout or because of another fuse inside the same fusebox.

Also, forceOpen the breaker only if it's not already open (saves computation time)