### PR TITLE
fix: switch to node:8 since semantic-release requires node >= 8

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -2,7 +2,7 @@ workflow:
     - publish
 
 shared:
-    image: node:6
+    image: node:8
 
 jobs:
     main:


### PR DESCRIPTION
semantic-release requires node >= 8

https://cd.screwdriver.cd/pipelines/22/builds/10454