### PR TITLE
fix: pin semantic release back and do not save dependency

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -12,7 +12,7 @@ jobs:
 
     publish:
         steps:
-            - install: npm install semantic-release
+            - install: npm install --no-save semantic-release@^7
             - publish: npm run semantic-release
         secrets:
             # Publishing to NPM


### PR DESCRIPTION
Semantic-release 8 requires node:8 which has not reached LTS. Pinning back, and do not save as dependency.