### PR TITLE
fix: log out args and errors for runCommand

### DIFF
--- a/index.js
+++ b/index.js
@@ -89,6 +89,7 @@ was tripped on ${new Date().toUTCString()}`);
 
                 if (err) {
                     console.log(`Getting errors with ${args}: ${err}`);
+
                     return reject(err);
                 }
 

--- a/index.js
+++ b/index.js
@@ -88,6 +88,7 @@ was tripped on ${new Date().toUTCString()}`);
                 }
 
                 if (err) {
+                    console.log(`Getting errors with ${args}: ${err}`);
                     return reject(err);
                 }
 

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -1,16 +1,15 @@
-workflow:
-    - publish
-
 shared:
     image: node:6
 
 jobs:
     main:
+        requires: [~pr, ~commit]
         steps:
             - install: npm install
             - test: npm test
 
     publish:
+        requires: main
         steps:
             - install: npm install --no-save semantic-release@^7
             - publish: npm run semantic-release


### PR DESCRIPTION
When runCommand failed, log out the args and errors so that we know where exactly it failed