### PR TITLE
fix: Increase default timeout value

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ class CircuitBreaker extends EventEmitter {
 
         this.command = command;
         this.breakerOptions = {
-            timeout: breakerOptions.timeout || 10000,
+            timeout: breakerOptions.timeout || 15000,
             maxFailures: breakerOptions.maxFailures || 5,
             resetTimeout: breakerOptions.resetTimeout || 50,
             errorFn: breakerOptions.errorFn || (() => true)


### PR DESCRIPTION
## Context

Lately, pull requests with a large number of changes files results in Circuit Breaker timeout for scm-github plugin. The call takes around 12000 ms (Github limits the response to 300 files per call, so pagination take a while), but the default timeout is set to 10000 ms.

## Objective

This PR increases the default timeout to 15000 ms to give the longer calls a little more time to finish.

## References

Related to https://octokit.github.io/rest.js/#octokit-routes-pulls-list-files, https://github.com/screwdriver-cd/scm-github/blob/master/index.js#L1004-L1009

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
