### PR TITLE
[1] fix: Add error handling for CircuitBreaker timeout

### DIFF
--- a/index.js
+++ b/index.js
@@ -90,8 +90,8 @@ was tripped on ${new Date().toUTCString()}`);
                 if (err) {
                     // eslint-disable-next-line no-console
                     console.log(`Getting errors with ${JSON.stringify(args)}: ${err}`);
-                    if (err.message.indexOf('CircuitBreaker timeout') !== -1) {
-                        if (err.status === undefined) {
+                    if (err.status === undefined) {
+                        if (err.message.indexOf('CircuitBreaker timeout') !== -1) {
                             err.status = 504;
                         }
                     }

--- a/index.js
+++ b/index.js
@@ -91,7 +91,9 @@ was tripped on ${new Date().toUTCString()}`);
                     // eslint-disable-next-line no-console
                     console.log(`Getting errors with ${JSON.stringify(args)}: ${err}`);
                     if (err.message.indexOf('CircuitBreaker timeout') !== -1) {
-                        err.status = 504;
+                        if (err.status === undefined) {
+                            err.status = 504;
+                        }
                     }
 
                     return reject(err);

--- a/index.js
+++ b/index.js
@@ -90,6 +90,9 @@ was tripped on ${new Date().toUTCString()}`);
                 if (err) {
                     // eslint-disable-next-line no-console
                     console.log(`Getting errors with ${JSON.stringify(args)}: ${err}`);
+                    if (err.message.indexOf('CircuitBreaker timeout') !== -1) {
+                        err.status = 504;
+                    }
 
                     return reject(err);
                 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -248,6 +248,18 @@ describe('index test', () => {
                     assert.deepEqual(err, breakerError);
                 });
         });
+        it('Return error when the CircuitBreaker timeout', () => {
+            const breakerError = new Error('CircuitBreaker timeout');
+
+            breakerMock.rejects(breakerError);
+
+            return breaker.runCommand('1', '2')
+                .catch((err) => {
+                    assert.calledWith(breakerMock, '1', '2');
+                    assert.deepEqual(err, breakerError);
+                    assert.deepEqual(err.status, 504);
+                });
+        });
     });
 
     describe('getTotalRequests', () => {


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
The following comments  the fix.
https://github.com/screwdriver-cd/screwdriver/pull/2426#discussion_r619373149

Modify to return a status code when CircuitBreaker timeout.


## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
Add a status code to allow the API to handle errors correctly when calling CircuitBreaker.

In my production, I can see the following error in the log when it times out.
```
Error: CircuitBreaker timeout
```


## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
[2] https://github.com/screwdriver-cd/screwdriver/pull/2426

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
