### PR TITLE
fix(1961): remove request package

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "sinon": "^9.0.0"
   },
   "dependencies": {
-    "request": "^2.88.0",
     "retry-function": "^2.0.0",
     "screwdriver-logger": "^1.0.2",
     "screwdriver-node-circuitbreaker": "^1.0.0"


### PR DESCRIPTION
## Context

Request package is deprecated.

## Objective

This PR removes the unused request package from the package.json.

## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/1961

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
