### PR TITLE
fix: CircuitBreaker timeout error handling

### DIFF
--- a/index.js
+++ b/index.js
@@ -94,9 +94,9 @@ was tripped on ${new Date().toUTCString()}`);
 
                     if (err) {
                         logger.info(`Getting errors with ${JSON.stringify(args)}: ${err}`);
-                        if (err.status === undefined) {
+                        if (err.statusCode === undefined) {
                             if (err.message.indexOf('CircuitBreaker timeout') !== -1) {
-                                err.status = 504;
+                                err.statusCode = 504;
                             }
                         }
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -256,7 +256,7 @@ describe('index test', () => {
             return breaker.runCommand('1', '2').catch(err => {
                 assert.calledWith(breakerMock, '1', '2');
                 assert.deepEqual(err, breakerError);
-                assert.deepEqual(err.status, 504);
+                assert.deepEqual(err.statusCode, 504);
             });
         });
     });


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
The status code key returned by [screwdriver-request](https://github.com/screwdriver-cd/request) is `response.statusCode` and components using it are also.
Therefore, it seems that the error handling for `CircuitBreaker timeout` does not work when use [scm-gitlab](https://github.com/screwdriver-cd/scm-gitlab), [scm-bitbucket](https://github.com/screwdriver-cd/scm-bitbucket), [executor-k8s](https://github.com/screwdriver-cd/executor-k8s) and so on.

[scm-github](https://github.com/screwdriver-cd/scm-github) uses `response.status`, but [this PR](https://github.com/screwdriver-cd/scm-github/pull/202) will change it to use `statusCode` instead of `status`.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

- Fix `CircuitBreaker timeout` error handling.
- Fix tests.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
