### PR TITLE
fix: redact token in logs

### DIFF
--- a/index.js
+++ b/index.js
@@ -92,7 +92,12 @@ was tripped on ${new Date().toUTCString()}`);
                     }
 
                     if (err) {
-                        logger.info(`Getting errors with ${JSON.stringify(args)}: ${err}`);
+                        const safeArgs = JSON.stringify(
+                            args,
+                            (key, value) => key === 'token' ? '[REDACTED]' : value
+                        );
+
+                        logger.error(`Getting errors with ${safeArgs}: ${err}`);
                         if (err.statusCode === undefined) {
                             if (err.message.indexOf('CircuitBreaker timeout') !== -1) {
                                 err.statusCode = 504;

--- a/index.js
+++ b/index.js
@@ -92,10 +92,7 @@ was tripped on ${new Date().toUTCString()}`);
                     }
 
                     if (err) {
-                        const safeArgs = JSON.stringify(
-                            args,
-                            (key, value) => key === 'token' ? '[REDACTED]' : value
-                        );
+                        const safeArgs = JSON.stringify(args, (key, value) => (key === 'token' ? '[REDACTED]' : value));
 
                         logger.error(`Getting errors with ${safeArgs}: ${err}`);
                         if (err.statusCode === undefined) {


### PR DESCRIPTION
## Context

Token is getting leaked into logs

## Objective

This PR removes redacts the token from logs, eventually this can be moved to logger library to redact all types of tokens, secrets and keys in logs.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
